### PR TITLE
Fix invalid service registration and missing namespace

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -8,9 +8,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-// Registrar servicios
-builder.Services.AddSingleton<ScrapingService>();
-builder.Services.AddSingleton<FileDownloadService>(); // Nuevo servicio para manejar descargas
+// Registrar servicios necesarios
 
 var app = builder.Build();
 

--- a/TableDownloadService.cs
+++ b/TableDownloadService.cs
@@ -6,7 +6,8 @@ using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using System.IO.Compression; 
+using System.IO.Compression;
+using System.Linq;
 
 namespace diantokensearchback.Services
 {


### PR DESCRIPTION
## Summary
- remove registrations for missing services
- include System.Linq to allow use of LINQ methods

## Testing
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68478874b3088333a3abbd1317cee093